### PR TITLE
Fix ui binding

### DIFF
--- a/public/js/main_dev.js
+++ b/public/js/main_dev.js
@@ -14,7 +14,11 @@ function($, app, Marionette, Backbone, TemplateView, Model) {
         model.setTemplate(contextObj.template);
         view = new TemplateView({ model: model });
 
-        contextObj.extensionsRegion.show(view, 'electron');
+        //wait until phantom-pdf or potentially other view unbinds from extensions menu
+        //otherwise binding electron.width won't apply because phantom.width is still taking place
+        setTimeout(function() {
+          contextObj.extensionsRegion.show(view, 'electron');
+        }, 0);
       } else {
         if (view != null) {
           $(view.el).remove();


### PR DESCRIPTION
This should fix the binding of the ui controls to the model. 

The problem was that the electron backbone view was displayed and bound before the previous view from phantomjs extension was correctly unbound. Now it should let the other recipes' views unbound before rendering.
