### PR TITLE
Specify page size with JSON string

### DIFF
--- a/src/recipe.js
+++ b/src/recipe.js
@@ -21,6 +21,14 @@ function parseBoolean(param, defaultValue) {
   return defaultValue;
 }
 
+function parseIfJSON(str) {
+  try {
+    return JSON.parse(str);
+  } catch(e) {
+    return str;
+  }
+}
+
 export default function(conversion, request, response) {
   // TODO: add support for header and footer html when electron support printing header/footer
   return new Promises((resolve) => {
@@ -44,7 +52,7 @@ export default function(conversion, request, response) {
 
       pdf: {
         marginsType: numberOrUndefined(options.marginsType),
-        pageSize: options.format,
+        pageSize: parseIfJSON(options.format),
         printBackground: parseBoolean(options.printBackground, true),
         landscape: parseBoolean(options.landscape, false)
       }


### PR DESCRIPTION
Electron has the ability to set custom page sizes in micrometers (1000micrometers = 1millimeter) using an object: { width: 1000, height: 1000 } creates a page 1mm x 1mm. Adding a JSON.parse allows a JSON string for that size object, set as format in jsreport.