### PR TITLE
Update Readme to be clear about configuration key

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jsreport.use(require('jsreport-electron-pdf')({ strategy: 'electron-ipc' }));
 Configuration
 -------------
 
-Use `electron` key in the standard [jsreport config](https://github.com/jsreport/jsreport/blob/master/config.md) file.
+Use `electron-pdf` key in the standard [jsreport config](https://github.com/jsreport/jsreport/blob/master/config.md) file.
 
 Available options:
 


### PR DESCRIPTION
The key has changed in recent versions from electron to electron-pdf. Changing the readme to be more clear about this.